### PR TITLE
Bump actions/cache from v2 to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache python deps 💾
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.OS }}-python-${{ hashFiles('**/requirements-tests.txt') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
 
     env:
       MAPPROXY_TEST_COUCHDB: 'http://localhost:5984'

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -4,7 +4,7 @@ MarkupSafe==1.1.1
 Pillow==6.2.2;python_version<"3.0"
 Pillow==8.2.0;python_version in "3.6 3.7 3.8 3.9"
 Pillow==8.4.0;python_version>="3.10"
-PyYAML==5.4
+PyYAML==5.3.1
 Shapely==1.7.0
 WebOb==1.8.6
 WebTest==2.0.35


### PR DESCRIPTION
<!--

MapProxy is governed by a [Project Steering Committee (PSC)][1].
The PSC makes decisions on all aspects of the MapProxy project - both technical and non-technical.
Most decisions require a vote by the PSC on the [mapproxy-dev mailing list][2].

Please contact the [mapproxy-dev list][2] with a Request For Change (RFC) proposal if your pull request matches any item below:

- Changes to project infrastructure (e.g. tool, location or substantive configuration)
- Anything that could cause backward compatibility issues.
- Adding substantial amounts of new code.
- Changing inter-subsystem APIs, or objects.
- Anything that might be controversial.

You can read more about the voting process in the [PSC Guidelines][2].

[1]: https://github.com/mapproxy/mapproxy/wiki/PSC-Guidelines
[2]: https://lists.osgeo.org/mailman/listinfo/mapproxy-dev

-->
Bump actions/cache from v2 to v4
